### PR TITLE
Change the about section

### DIFF
--- a/content/authors/.gitignore
+++ b/content/authors/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -74,4 +74,6 @@ user_groups:
 - Visitors
 ---
 
-I am a research data scientist with 8+ years of experience in behavioral sciences. Through my work, I advance open science and transparency to decentralize power, promote the free distribution of knowledge, and amplify voices of historically underrepresented groups.
+I am a quantitative/data scientist with 8+ years of experience with human data. I believe in the power of openness and transparency in driving collaboration and equitable innovation.
+
+I love coding and solving technical problems. Interested in what I’m up to? Follow me on GitHub 👋

--- a/content/home/about.md
+++ b/content/home/about.md
@@ -5,7 +5,7 @@ headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
 weight = 20  # Order that this section will appear in.
 
-title = "Biography"
+title = "About"
 
 # Choose the user profile to display
 # This should be the username of a profile in your `content/authors/` folder.


### PR DESCRIPTION
This PR changes the Biography section to the About section and updates the content to be consistent with what's on LinkedIn.

- Ignore `.DS_Store`
- Update about
- Change `Biography` to `About`
